### PR TITLE
Improved UI-JA text

### DIFF
--- a/messages/ui-ja.json
+++ b/messages/ui-ja.json
@@ -30,8 +30,8 @@
     },
     "Target": {
       "Self": "自身",
-      "Random": "チームメンバ一つ",
-      "Team": "全チーム"
+      "Random": "チーム1匹",
+      "Team": "チーム全体"
     }
   },
   "Metadata": {
@@ -157,7 +157,7 @@
     "Pokedex": {
       "Info": {
         "Berry": "きのみ",
-        "Evolution": "進化階段",
+        "Evolution": "進化段階",
         "Ingredient": "食材",
         "MainSkill": "メインスキル",
         "Name": "名前",


### PR DESCRIPTION
Background info:
- `階段` for evo stages is a ZH term; `段階` is common in JA
- Although `全チーム` can mean "the whole team" it sounds more like "for all the team**s**"; `チーム全体` should be clearer for the target description as it better implies "entirely within the team"