### PR TITLE
Added sleep style counter to pokemon info page #263

### DIFF
--- a/src/ui/pokedex/page/sleepStyle/loaded.tsx
+++ b/src/ui/pokedex/page/sleepStyle/loaded.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 
 import {Flex} from '@/components/layout/flex/common';
+import {CompletionResultUI} from '@/components/shared/completion/main';
 import {SleepdexMap} from '@/types/game/sleepdex';
 import {PokemonSleepStylesIncenseOnly} from '@/ui/pokedex/page/sleepStyle/incenseOnly';
 import {PokemonSleepStylesOfMap} from '@/ui/pokedex/page/sleepStyle/map';
 import {PokemonDataProps} from '@/ui/pokedex/page/type';
+import {toUnique} from '@/utils/array';
+import {isInSleepdex} from '@/utils/game/sleepdex';
 
 
 type Props = PokemonDataProps & {
@@ -23,6 +26,25 @@ export const PokemonSleepStylesLoaded = ({
   if (sleepStyles.length === 0) {
     return null;
   }
+
+  const availableSleepStyles = toUnique([
+    ...sleepStyles.flatMap((sleepStyleNormal) => (
+      sleepStyleNormal.styles.map((sleepStyle) => (
+        sleepStyle.style
+      ))
+    )),
+    ...sleepStylesSpecial.map((sleepStyleSpecial) => (
+      sleepStyleSpecial.style
+    )),
+  ]);
+
+  const unlockedSleepStyles = availableSleepStyles.reduce<number>((unlockedSleepStyles, current) => {
+    if (isInSleepdex({sleepdex, pokemonId: pokemon.id, styleId: current})) {
+      return unlockedSleepStyles + 1;
+    }
+
+    return unlockedSleepStyles;
+  }, 0);
 
   return (
     <Flex center wrap className="info-section md:flex-row">
@@ -43,6 +65,12 @@ export const PokemonSleepStylesLoaded = ({
         setSleepdex={setSleepdex}
         sleepStylesIncenseOnly={sleepStylesSpecial}
       />
+      <Flex direction="row" center className="justify-end">
+        <CompletionResultUI
+          completed={unlockedSleepStyles}
+          total={availableSleepStyles.length}
+        />
+      </Flex>
     </Flex>
   );
 };


### PR DESCRIPTION
Resolves #263 

Looking for guidance on formatting lines 37 and 47 so they're shorter. 

This implementation uses `SleepStyleNormal` and `SleepStyleSpecial` to record the Pokemon's individual total sleep styles and the user's unlocked sleep styles for it. If there exists a better type to determine this information, then I will refactor this. 