### PR TITLE
Removed memoization hooks in team analysis

### DIFF
--- a/src/ui/team/analysis/calc/hook/main.ts
+++ b/src/ui/team/analysis/calc/hook/main.ts
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {MealCoverage} from '@/types/game/cooking';
 import {ProducingRate} from '@/types/game/producing/rate';
 import {getTeamCompCalcResult} from '@/ui/team/analysis/calc/comp';
@@ -14,28 +12,20 @@ import {getTotalOfGroupedProducingRate} from '@/utils/game/producing/rateReducer
 
 export const useTeamProducingStats = (opts: UseTeamProducingStatsOpts): TeamProducingStats => {
   const {
-    setup,
-    bundle,
     currentTeam,
     cookingSettings,
   } = opts;
   const {
     snorlaxFavorite,
     analysisPeriod,
-    members,
   } = currentTeam;
 
-  const deps: React.DependencyList = [snorlaxFavorite, analysisPeriod, members, setup, bundle];
-
-  const compsStats = React.useMemo(
-    () => getTeamCompCalcResult({
-      period: analysisPeriod,
-      state: stateOfRateToShow,
-      snorlaxFavorite,
-      ...opts,
-    }),
-    deps,
-  );
+  const compsStats = getTeamCompCalcResult({
+    period: analysisPeriod,
+    state: stateOfRateToShow,
+    snorlaxFavorite,
+    ...opts,
+  });
   const {
     bySlot,
     grouped,
@@ -45,20 +35,19 @@ export const useTeamProducingStats = (opts: UseTeamProducingStatsOpts): TeamProd
     period: analysisPeriod,
     bySlot,
     state: stateOfRateToShow,
-    deps,
   });
 
-  const overall: ProducingRate = React.useMemo(() => ({
+  const overall: ProducingRate = {
     period: analysisPeriod,
     energy: getTotalOfGroupedProducingRate({rate: total, key: 'energy'}),
     quantity: getTotalOfGroupedProducingRate({rate: total, key: 'quantity'}),
-  }), deps);
+  };
 
-  const mealCoverage: MealCoverage = React.useMemo(() => getMealCoverage({
+  const mealCoverage: MealCoverage = getMealCoverage({
     meals: cookingSettings.targetMeals,
     ingredientProduction: toIngredientProductionCounterFromGroupedRate(grouped.ingredient),
     period: analysisPeriod,
-  }), deps);
+  });
 
   return {
     total,

--- a/src/ui/team/analysis/calc/hook/total.ts
+++ b/src/ui/team/analysis/calc/hook/total.ts
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {teamAnalysisSlotName} from '@/types/teamAnalysis';
 import {UseTeamProducingStatsCommonOpts} from '@/ui/team/analysis/calc/type';
 import {TeamProducingStatsBySlot, TeamProducingStatsTotal} from '@/ui/team/analysis/setup/type';
@@ -9,15 +7,13 @@ import {isNotNullish} from '@/utils/type';
 
 type UseTeamProducingStatsTotalOpts = UseTeamProducingStatsCommonOpts & {
   bySlot: TeamProducingStatsBySlot,
-  deps: React.DependencyList,
 };
 
 export const useTeamProducingStatsTotal = ({
   period,
   state,
   bySlot,
-  deps,
-}: UseTeamProducingStatsTotalOpts): TeamProducingStatsTotal => React.useMemo(() => {
+}: UseTeamProducingStatsTotalOpts): TeamProducingStatsTotal => {
   const stats = teamAnalysisSlotName
     .map((slotName) => bySlot[slotName])
     .filter(isNotNullish);
@@ -51,4 +47,4 @@ export const useTeamProducingStatsTotal = ({
       quantity: toSum(stats.map(({skill}) => skill.quantity[state])),
     },
   };
-}, deps);
+};

--- a/src/ui/team/analysis/calc/slot.ts
+++ b/src/ui/team/analysis/calc/slot.ts
@@ -31,7 +31,6 @@ export const getTeamProducingStatsSlot = ({
 }: GetTeamProducingStatsSlotOpts): GetProducingStatsOptsSlotReturn | null => {
   const {members} = currentTeam;
 
-  // return React.useMemo(() => {
   const member = members[slotName];
   if (!member) {
     return null;

--- a/src/ui/team/analysis/client/utils.ts
+++ b/src/ui/team/analysis/client/utils.ts
@@ -1,0 +1,42 @@
+import {v4} from 'uuid';
+
+import {TeamAnalysisComp, TeamAnalysisConfig, TeamAnalysisSetup} from '@/types/teamAnalysis';
+import {UserTeamAnalysisContent} from '@/types/userData/teamAnalysis';
+import {generateEmptyTeam} from '@/ui/team/analysis/utils';
+import {migrate} from '@/utils/migrate/main';
+import {teamAnalysisCompMigrators} from '@/utils/migrate/teamAnalysis/comp/migrators';
+import {teamAnalysisConfigMigrators} from '@/utils/migrate/teamAnalysis/config/migrators';
+import {Nullable} from '@/utils/type';
+
+
+type GetInitialTeamAnalysisSetupOpts = {
+  data: Nullable<UserTeamAnalysisContent>,
+};
+
+export const getInitialTeamAnalysisSetup = ({data}: GetInitialTeamAnalysisSetupOpts): TeamAnalysisSetup => {
+  // Migrate first for older data version
+  // If the user is not logged in or new, they won't have `preloadedSetup` so they need an initial comp
+  // Therefore generate the initial comp for migration, then ignore it if it's not needed
+  const initialCompUuid = v4();
+  const config: TeamAnalysisConfig = migrate({
+    original: {
+      current: initialCompUuid,
+      version: teamAnalysisConfigMigrators.length,
+    },
+    override: data?.config ?? null,
+    migrators: teamAnalysisConfigMigrators,
+    migrateParams: {},
+  });
+
+  const compsToMigrate = data?.comps ?? [generateEmptyTeam(initialCompUuid)];
+  const comps: TeamAnalysisComp[] = compsToMigrate.map((team) => migrate({
+    original: generateEmptyTeam(team.uuid),
+    override: team,
+    migrators: teamAnalysisCompMigrators,
+    migrateParams: {},
+  }));
+  return {
+    config,
+    comps: Object.fromEntries(comps.map((team) => [team.uuid, team])),
+  };
+};

--- a/src/ui/team/analysis/setup/team/filled.tsx
+++ b/src/ui/team/analysis/setup/team/filled.tsx
@@ -21,7 +21,7 @@ export const TeamAnalysisFilledSlot = (props: Props) => {
   const t = useTranslations('UI.Metadata.Pokedex');
   const t2 = useTranslations('Game.PokemonName');
 
-  const setTeamMember = React.useCallback((slotName: TeamAnalysisSlotName, update: Partial<TeamAnalysisMember>) => {
+  const setTeamMember = (slotName: TeamAnalysisSlotName, update: Partial<TeamAnalysisMember>) => {
     // `merge()` keeps the original value if the `update` is undefined, but `update` should overwrite it
     setSetup((original) => ({
       ...original,
@@ -39,7 +39,7 @@ export const TeamAnalysisFilledSlot = (props: Props) => {
         },
       },
     }));
-  }, [setSetup]);
+  };
 
   return (
     <>

--- a/src/ui/team/analysis/setup/team/main.tsx
+++ b/src/ui/team/analysis/setup/team/main.tsx
@@ -44,7 +44,7 @@ export const TeamAnalysisTeamView = (props: Props) => {
   const t = useTranslations('Game');
   const {members, snorlaxFavorite} = currentTeam;
 
-  const setMember = React.useCallback((
+  const setMember = (
     slotName: TeamAnalysisSlotName,
     member: TeamAnalysisMember,
   ) => {
@@ -74,7 +74,7 @@ export const TeamAnalysisTeamView = (props: Props) => {
         </div>
       </Flex>
     )});
-  }, [setSetup, getCurrentTeam]);
+  };
 
   return (
     <Grid className="grid-cols-1 gap-1.5 lg:grid-cols-3 xl:grid-cols-5">


### PR DESCRIPTION
Closes #671

This removes some memoization React hooks, mainly `useCallback()` and `useMemo()` in hope of fixing iOS lagging issue.